### PR TITLE
 FIX: Fixed error in Windows if NEURON was not in default path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 mat/figures
 mat/cell_data/*
 !mat/cell_data/cell_models_all.mat
+
+# NEURON-compiled files
+*.o
+*.c

--- a/mat/initializeCellData.m
+++ b/mat/initializeCellData.m
@@ -2,6 +2,15 @@
 % uses defaults from Aberra et al. 2019
 function initializeCellData()
 mat_dir = addPaths; 
+
+%% Check that nrnmech.dll file exists, if not display a warning message
+nrnmech_file = fullfile(mat_dir, '../nrn', 'nrnmech.dll');
+if ~isfile(nrnmech_file)
+    msg = 'nrniv.exe does not exist. Compile mechanisms and move nrniv.exe to nrn folder';
+    f = warndlg(msg, 'modal');
+    return
+end
+
 %% Generate cell data (based on neuron models placed in '../nrn/cells/'
 writeCellModelTable(); % creates cell_data/cell_data.mat, called by cellModelNames
 cell_model_names = cellModelNames; % outputs all cell_model_names

--- a/mat/run_nrn_functions/saveCellData.m
+++ b/mat/run_nrn_functions/saveCellData.m
@@ -29,11 +29,16 @@ cd(nrn_dir); % launch init_run_stim.hoc from here
 nrn_file = fullfile(nrn_dir,'init_field_stim.hoc'); 
 commands = sprintf(' -c "run_name=\\"%s"\\" -c "loadFiles()" -c "cell_chooser(cell_id,cell_model_name)" -c "save_cell_data()" -c "quit()"',simulation.run_name);                    
 options = sprintf('-nopython -NSTACK %g -NFRAME %g ',100000,20000);
-if ispc    
-    system(['C:\nrn\bin\nrniv.exe -nobanner ' options nrn_file commands]);
-elseif isunix       
+
+if ispc
+    % Get the NEURON installation path to execute the code
+    nrn_install_path = getenv('NEURONHOME');
+    system([fullfile(nrn_install_path, 'bin', 'nrniv.exe') ' -nobanner ' options nrn_file commands]);
+    %     system(['C:\nrn\bin\nrniv.exe -nobanner ' options nrn_file commands]);
+elseif isunix
     system(['./special ' options nrn_file commands]);
 end
+    
 cd(mat_dir); % launch init_run_stim.hoc from here
 %% neuron data files
 coords_file = fullfile(run_tmp_fold,sprintf('coordinates%g.txt',cell_id)); 

--- a/nrn/mosinit.ps1
+++ b/nrn/mosinit.ps1
@@ -1,1 +1,2 @@
-C:\nrn\bin\nrniv.exe -NSTACK 100000 -NFRAME 20000 -Py_NoSiteFlag init_field_stim_test.hoc
+$nrnpath = Join-Path -Path $env:neuronhome -ChildPath "bin\nrniv.exe"
+& $nrnpath -NSTACK 100000 -NFRAME 20000 -Py_NoSiteFlag init_field_stim_test.hoc


### PR DESCRIPTION
- Uses $NEURONHOME$ environment variable in Windows to check NEURON path both in Matlab and PowerShell scripts